### PR TITLE
Check to prevent several simultaneous refresh requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-authentication",
-  "version": "1.0.1",
+  "version": "1.0.6",
   "homepage": "https://github.com/interactive-solutions/ts-authentication",
   "authors": [
     "Antoine Hedgecock <antoine.hedgecock@gmail.com>",

--- a/src/service.ts
+++ b/src/service.ts
@@ -193,9 +193,7 @@ module is.authentication {
           this.storage.clear();
           this.emit('authentication-changed', this);
         })
-        .finally(() => {
-          this.refreshPromise = null;
-        });
+        .finally(() => this.refreshPromise = null);
 
       return this.refreshPromise;
     }


### PR DESCRIPTION
If we have a pending refresh request we should return that one instead of sending several simultaneous requests.